### PR TITLE
Feature/tp 180096 trocar nome voce para wingo

### DIFF
--- a/src/components/Chat/Maximized/MessageView/Message/Message.js
+++ b/src/components/Chat/Maximized/MessageView/Message/Message.js
@@ -69,7 +69,7 @@ export const Message = ({
             <Typography variant="caption" className={classes.authorName}>
               {/* Workaround to overcome lack of authorName on message object */}
               {message.authorName}
-              {!isStringNotBlank(message.authorName) && message.own && 'Você'}
+              {!isStringNotBlank(message.authorName) && message.own && 'Wingo'}
               {!isStringNotBlank(message.authorName) && !message.own && title}
             </Typography>
           )


### PR DESCRIPTION
Substituir o nome do remetente de "Voce" para "Wingo" quando o usuário que enviou a mensagem não estiver definido