### PR TITLE
[#182725] Tornar a visualização das mensagens de uma conversa algo mais próximo daquilo que o cliente realmente recebeu ou enviou

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@mdi/react": "^1.4.0",
     "@tecsinapse/es-utils": "^6.0.10",
     "@tecsinapse/react-mic": "1.3.3",
-    "@tecsinapse/ui-kit": "^5.6.3",
+    "@tecsinapse/ui-kit": "^5.6.10",
     "@tecsinapse/uploader": "^2.6.5",
     "clsx": "^1.1.1",
     "enumify": "^1.0.4",

--- a/src/components/Chat/Maximized/MessageView/Message/Message.js
+++ b/src/components/Chat/Maximized/MessageView/Message/Message.js
@@ -14,7 +14,10 @@ import clsx from 'clsx';
 import Icon from '@mdi/react';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Tooltip from '@material-ui/core/Tooltip';
-import { IconButton as IconButtonMaterial } from '@tecsinapse/ui-kit';
+import {
+  IconButton as IconButtonMaterial,
+  MessagePreviewUtils,
+} from '@tecsinapse/ui-kit';
 
 import { DeliveryStatus } from './DeliveryStatus/DeliveryStatus';
 
@@ -113,7 +116,12 @@ export const Message = ({
           >
             {message.text && !isInfoStyle && (
               <MessageText>
-                <Typography variant="body1">{message.text}</Typography>
+                <Typography
+                  variant="body1"
+                  dangerouslySetInnerHTML={{
+                    __html: MessagePreviewUtils.normalizeInHtml(message.text),
+                  }}
+                />
               </MessageText>
             )}
             {message.title && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3579,6 +3579,24 @@
   resolved "https://registry.yarnpkg.com/@tecsinapse/react-mic/-/react-mic-1.3.3.tgz#095b7d12f6f1f5957f202b4d2d67800740f3a359"
   integrity sha512-qVcFX+o18wqsXi1+FEp/0ov2mV2S/L778zaApz9zAvD/tYfrC/vaqIs5eh/5YYG/yIP/pi37G2gOQT9/BW/kTg==
 
+"@tecsinapse/ui-kit@^5.6.10":
+  version "5.6.10"
+  resolved "https://registry.yarnpkg.com/@tecsinapse/ui-kit/-/ui-kit-5.6.10.tgz#d8a6c650976f2e7d9fcca17e3010985eda32630e"
+  integrity sha512-RluFkGLvTBwqw7BIAu1auy6XeCgEDvWQR9lqBHARFa/sfSu40DaagsvWF+1OVVpwTevfdR4aTNwrIfCYbof9KA==
+  dependencies:
+    "@material-ui/core" "^4.11.1"
+    "@material-ui/icons" "^4.11.1"
+    "@material-ui/styles" "^4.11.1"
+    "@mdi/js" "^5.9.55"
+    "@mdi/react" "^1.4.0"
+    "@tecsinapse/es-utils" "^6.0.10"
+    material-ui-search-bar "1.0.0"
+    react-select "^3.2.0"
+    react-sizeme "^3.0.1"
+    react-text-mask "^5.4.3"
+    text-mask-addons "^3.8.0"
+    text-mask-core "^5.1.2"
+
 "@tecsinapse/ui-kit@^5.6.3":
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/@tecsinapse/ui-kit/-/ui-kit-5.6.3.tgz#2269bb67e271c7f69b056e091f3717f8d2b60e8a"


### PR DESCRIPTION
Atualmente a visualização de uma mensagem enviada/recebida não formata a mensagem conforme as regras da Meta. Ou seja: não exibimos negrito, italico etc.